### PR TITLE
Feat/blur nsfw preview

### DIFF
--- a/scripts/mo/data/firebase_storage.py
+++ b/scripts/mo/data/firebase_storage.py
@@ -10,6 +10,8 @@ from scripts.mo.data.storage import Storage, map_dict_to_record, map_record_to_d
 from scripts.mo.environment import env
 from scripts.mo.models import Record
 
+FIREBASE_APP_NAME = "sd-model-organizer-app"
+
 
 def _filter_download(record: Record, show_downloaded, show_not_downloaded):
     is_downloaded = bool(record.location) and os.path.exists(record.location)
@@ -19,9 +21,12 @@ def _filter_download(record: Record, show_downloaded, show_not_downloaded):
 class FirebaseStorage(Storage):
 
     def __init__(self):
-        cred = credentials.Certificate(os.path.join(env.script_dir, "service-account-file.json"))
-        self.app = firebase_admin.initialize_app(cred)
-        self.firestore_client = firestore.client()
+        if not firebase_admin._apps:
+            cred = credentials.Certificate(os.path.join(env.script_dir, "service-account-file.json"))
+            self.app = firebase_admin.initialize_app(cred, name=FIREBASE_APP_NAME)
+        else:
+            self.app = firebase_admin.get_app(name=FIREBASE_APP_NAME)
+        self.firestore_client = firestore.client(app=self.app)
 
     def _records(self) -> CollectionReference:
         return self.firestore_client.collection('records')

--- a/scripts/mo/environment.py
+++ b/scripts/mo/environment.py
@@ -60,6 +60,7 @@ class Environment:
 
     storage_type: Callable[[], str]
     download_preview: Callable[[], bool]
+    nsfw_blur: Callable[[], bool]
     model_path: Callable[[], str]
     vae_path: Callable[[], str]
     lora_path: Callable[[], str]

--- a/scripts/mo/ui_edit.py
+++ b/scripts/mo/ui_edit.py
@@ -144,11 +144,16 @@ def _on_id_changed(record_data):
     if record_data.get('record_id') is not None and record_data['record_id']:
         record = env.storage.get_record_by_id(record_data['record_id'])
     elif record_data.get('prefilled_json') is not None and record_data['prefilled_json']:
-        prefilled_json = record_data['prefilled_json']
-        prefilled_unescaped = html.unescape(prefilled_json)
-        prefilled_slash_escaped = prefilled_unescaped.replace('\\', '\\\\')
-        prefilled = json.loads(prefilled_slash_escaped)
-        record = map_dict_to_record(prefilled.get('id_'), prefilled)
+        try:
+            prefilled_json = record_data['prefilled_json']
+            prefilled = json.loads(r"" + prefilled_json)
+            record = map_dict_to_record(prefilled.get('id_'), prefilled)
+        except json.decoder.JSONDecodeError:
+            prefilled_json = record_data['prefilled_json']
+            prefilled_unescaped = html.unescape(prefilled_json)
+            prefilled_slash_escaped = prefilled_unescaped.replace('\\', '\\\\')
+            prefilled = json.loads(prefilled_slash_escaped)
+            record = map_dict_to_record(prefilled.get('id_'), prefilled)
     else:
         record = None
 
@@ -164,7 +169,7 @@ def _on_id_changed(record_data):
     else:
         download_url = gr.Textbox.update(
             value=record.download_url,
-            label="""Download URL: (If URL will be changed - SHA256, MD5 and file location will be erased. 
+            label="""Download URL: (If URL will be changed - SHA256, MD5 and file location will be erased.
                   Remove file manually or via remove-files only option)"""
         )
 

--- a/scripts/mo/ui_styled_html.py
+++ b/scripts/mo/ui_styled_html.py
@@ -313,8 +313,11 @@ def record_details(record: Record) -> str:
 def records_cards(records: List) -> str:
     content = '<div class="mo-card-grid">'
 
+    nsfw_blur = env.nsfw_blur()
+
     for record in records:
-        content += '<div class="mo-card">'
+        contains_nsfw = any('nsfw' in group.lower() for group in record.groups) and nsfw_blur
+        content += f'<div class="mo-card {"blur" if contains_nsfw else ""}">'
 
         preview_url = get_best_preview_url(record)
         content += f'<img src="{preview_url}" alt="Preview Image" ' \

--- a/scripts/model_organizer.py
+++ b/scripts/model_organizer.py
@@ -40,7 +40,10 @@ def _default_lora_path() -> str:
 
 
 def _default_hypernetworks_path() -> str:
-    if hasattr(shared.cmd_opts, 'hypernetwork_dir') and shared.cmd_opts.hypernetwork_dir:
+    if (
+        hasattr(shared.cmd_opts, 'hypernetwork_dir')
+        and shared.cmd_opts.hypernetwork_dir
+    ):
         return shared.cmd_opts.hypernetwork_dir
     else:
         return os.path.join(paths.models_path, 'hypernetworks')
@@ -67,38 +70,76 @@ def _lycoris_path() -> str:
         return _default_lycoris_path()
 
 
-env.layout = lambda: shared.opts.mo_layout if hasattr(shared.opts, 'mo_layout') else LAYOUT_CARDS
+env.layout = (
+    lambda: shared.opts.mo_layout if hasattr(shared.opts, 'mo_layout') else LAYOUT_CARDS
+)
 
-env.card_width = lambda: shared.opts.mo_card_width if hasattr(shared.opts, 'mo_card_width') and \
-                                                      shared.opts.mo_card_width else DEFAULT_CARD_WIDTH
+env.card_width = (
+    lambda: shared.opts.mo_card_width
+    if hasattr(shared.opts, 'mo_card_width') and shared.opts.mo_card_width
+    else DEFAULT_CARD_WIDTH
+)
 
-env.card_height = lambda: shared.opts.mo_card_height if hasattr(shared.opts, 'mo_card_height') and \
-                                                        shared.opts.mo_card_height else DEFAULT_CARD_HEIGHT
+env.card_height = (
+    lambda: shared.opts.mo_card_height
+    if hasattr(shared.opts, 'mo_card_height') and shared.opts.mo_card_height
+    else DEFAULT_CARD_HEIGHT
+)
 
-env.storage_type = lambda: shared.opts.mo_storage_type if hasattr(shared.opts, 'mo_storage_type') else STORAGE_SQLITE
+env.storage_type = (
+    lambda: shared.opts.mo_storage_type
+    if hasattr(shared.opts, 'mo_storage_type')
+    else STORAGE_SQLITE
+)
 
-env.download_preview = lambda: shared.opts.mo_download_preview if hasattr(shared.opts,
-                                                                          'mo_download_preview') else True
+env.download_preview = (
+    lambda: shared.opts.mo_download_preview
+    if hasattr(shared.opts, 'mo_download_preview')
+    else True
+)
 
-env.model_path = lambda: shared.opts.mo_model_path if hasattr(shared.opts, 'mo_model_path') and \
-                                                      shared.opts.mo_model_path else _default_model_path()
+env.nsfw_blur = (
+    lambda: shared.opts.mo_nsfw_blur
+    if hasattr(shared.opts, 'mo_nsfw_blur')
+    else True
+)
 
-env.vae_path = lambda: shared.opts.mo_vae_path if hasattr(shared.opts, 'mo_vae_path') and \
-                                                  shared.opts.mo_vae_path else _default_vae_path()
+env.model_path = (
+    lambda: shared.opts.mo_model_path
+    if hasattr(shared.opts, 'mo_model_path') and shared.opts.mo_model_path
+    else _default_model_path()
+)
 
-env.lora_path = lambda: shared.opts.mo_lora_path if hasattr(shared.opts, 'mo_lora_path') and \
-                                                    shared.opts.mo_lora_path else _default_lora_path()
+env.vae_path = (
+    lambda: shared.opts.mo_vae_path
+    if hasattr(shared.opts, 'mo_vae_path') and shared.opts.mo_vae_path
+    else _default_vae_path()
+)
 
-env.hypernetworks_path = lambda: shared.opts.mo_hypernetworks_path if \
-    hasattr(shared.opts,
-            'mo_hypernetworks_path') and shared.opts.mo_hypernetworks_path else _default_hypernetworks_path()
+env.lora_path = (
+    lambda: shared.opts.mo_lora_path
+    if hasattr(shared.opts, 'mo_lora_path') and shared.opts.mo_lora_path
+    else _default_lora_path()
+)
+
+env.hypernetworks_path = (
+    lambda: shared.opts.mo_hypernetworks_path
+    if hasattr(shared.opts, 'mo_hypernetworks_path')
+    and shared.opts.mo_hypernetworks_path
+    else _default_hypernetworks_path()
+)
 
 env.lycoris_path = _lycoris_path
 
-env.embeddings_path = lambda: shared.opts.mo_embeddings_path if \
-    hasattr(shared.opts, 'mo_embeddings_path') and shared.opts.mo_embeddings_path else _default_embeddings_path()
+env.embeddings_path = (
+    lambda: shared.opts.mo_embeddings_path
+    if hasattr(shared.opts, 'mo_embeddings_path') and shared.opts.mo_embeddings_path
+    else _default_embeddings_path()
+)
 
-env.is_debug_mode_enabled = lambda: hasattr(shared.cmd_opts, 'mo_debug') and shared.cmd_opts.mo_debug
+env.is_debug_mode_enabled = (
+    lambda: hasattr(shared.cmd_opts, 'mo_debug') and shared.cmd_opts.mo_debug
+)
 
 env.script_dir = scripts.basedir()
 env.theme = lambda: shared.cmd_opts.theme
@@ -106,29 +147,53 @@ env.theme = lambda: shared.cmd_opts.theme
 
 def on_ui_settings():
     opts = {
-        'mo_layout': OptionInfo(LAYOUT_CARDS, "Layout Type:", gr.Radio,
-                                {"choices": [LAYOUT_CARDS, LAYOUT_TABLE]}),
+        'mo_layout': OptionInfo(
+            LAYOUT_CARDS,
+            "Layout Type:",
+            gr.Radio,
+            {"choices": [LAYOUT_CARDS, LAYOUT_TABLE]},
+        ),
         'mo_card_width': OptionInfo(250, 'Card width (250 default value):'),
         'mo_card_height': OptionInfo(350, 'Card height (350 default value):'),
-        'mo_storage_type': OptionInfo(STORAGE_SQLITE, "Storage Type:", gr.Radio,
-                                      {"choices": [STORAGE_SQLITE, STORAGE_FIREBASE]}),
+        'mo_storage_type': OptionInfo(
+            STORAGE_SQLITE,
+            "Storage Type:",
+            gr.Radio,
+            {"choices": [STORAGE_SQLITE, STORAGE_FIREBASE]},
+        ),
         'mo_download_preview': OptionInfo(True, 'Download Preview'),
+        'mo_nsfw_blur': OptionInfo(True, 'Blur NSFW Previews (models with "nsfw" tag)'),
     }
 
     dir_opts = {
-        'mo_model_path': OptionInfo('', f'Model directory (If empty uses default: {_default_model_path()}):'),
-        'mo_vae_path': OptionInfo('', f'VAE directory (If empty uses default: {_default_vae_path()}) :'),
-        'mo_lora_path': OptionInfo('', f'Lora directory (If empty uses default: {_default_lora_path()}):'),
-        'mo_hypernetworks_path': OptionInfo('',
-                                            f'Hypernetworks directory (If empty uses default: '
-                                            f'{_default_hypernetworks_path()}):'),
-        'mo_lycoris_path': OptionInfo('',
-                                      f'LyCORIS directory (If empty uses default: {_default_lycoris_path()}):'),
-        'mo_embeddings_path': OptionInfo('', f'Embeddings directory (If empty uses default: '
-                                             f'{_default_embeddings_path()}):')
+        'mo_model_path': OptionInfo(
+            '', f'Model directory (If empty uses default: {_default_model_path()}):'
+        ),
+        'mo_vae_path': OptionInfo(
+            '', f'VAE directory (If empty uses default: {_default_vae_path()}) :'
+        ),
+        'mo_lora_path': OptionInfo(
+            '', f'Lora directory (If empty uses default: {_default_lora_path()}):'
+        ),
+        'mo_hypernetworks_path': OptionInfo(
+            '',
+            f'Hypernetworks directory (If empty uses default: '
+            f'{_default_hypernetworks_path()}):',
+        ),
+        'mo_lycoris_path': OptionInfo(
+            '', f'LyCORIS directory (If empty uses default: {_default_lycoris_path()}):'
+        ),
+        'mo_embeddings_path': OptionInfo(
+            '',
+            f'Embeddings directory (If empty uses default: '
+            f'{_default_embeddings_path()}):',
+        ),
     }
 
-    if hasattr(shared.cmd_opts, 'mo_show_dir_settings') and shared.cmd_opts.mo_show_dir_settings:
+    if (
+        hasattr(shared.cmd_opts, 'mo_show_dir_settings')
+        and shared.cmd_opts.mo_show_dir_settings
+    ):
         opts.update(dir_opts)
 
     mo_options = shared.options_section(('mo', 'Model Organizer'), opts)
@@ -138,14 +203,26 @@ def on_ui_settings():
 
 def on_ui_tabs():
     if env.is_debug_mode_enabled():  # TODO Remove these lines
-        ui_extra_networks.allowed_dirs.add('/Users/alexander/Downloads/sd-downloads/ckpt')
-        ui_extra_networks.allowed_dirs.add('/Users/alexander/Downloads/sd-downloads/vae')
-        ui_extra_networks.allowed_dirs.add('/Users/alexander/Downloads/sd-downloads/embeddings')
-        ui_extra_networks.allowed_dirs.add('/Users/alexander/Downloads/sd-downloads/hypernetworks')
-        ui_extra_networks.allowed_dirs.add('/Users/alexander/Downloads/sd-downloads/lora')
-        ui_extra_networks.allowed_dirs.add('/Users/alexander/Downloads/sd-downloads/lyco')
+        ui_extra_networks.allowed_dirs.add(
+            '/Users/alexander/Downloads/sd-downloads/ckpt'
+        )
+        ui_extra_networks.allowed_dirs.add(
+            '/Users/alexander/Downloads/sd-downloads/vae'
+        )
+        ui_extra_networks.allowed_dirs.add(
+            '/Users/alexander/Downloads/sd-downloads/embeddings'
+        )
+        ui_extra_networks.allowed_dirs.add(
+            '/Users/alexander/Downloads/sd-downloads/hypernetworks'
+        )
+        ui_extra_networks.allowed_dirs.add(
+            '/Users/alexander/Downloads/sd-downloads/lora'
+        )
+        ui_extra_networks.allowed_dirs.add(
+            '/Users/alexander/Downloads/sd-downloads/lyco'
+        )
 
-    return (main_ui_block(), "Model Organizer", "model_organizer"),
+    return ((main_ui_block(), "Model Organizer", "model_organizer"),)
 
 
 def on_app_started(demo: Optional[Blocks], app: FastAPI):

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -464,6 +464,7 @@
     border-radius: 8px;
     /*justify-self: start;*/
     position: relative;
+    overflow: hidden;
 }
 
 .mo-card img {
@@ -472,6 +473,10 @@
     border-radius: 8px;
     object-fit: cover;
     object-position: center;
+}
+
+.blur img {
+    filter: blur(10px);
 }
 
 .mo-card-blur-overlay-bottom {


### PR DESCRIPTION
Introduce a new feature that allows users to enable blur in image previews for models tagged (grouped) as nsfw.

Blurred preview example:
![image](https://github.com/alexandersokol/sd-model-organizer/assets/33515228/4bfecbb0-3f76-4489-af56-7e5120d3d168)

Setting:
![image](https://github.com/alexandersokol/sd-model-organizer/assets/33515228/46d45c00-4d54-4f73-996a-a5cc19c69671)

