### PR TITLE
fix text overflow at overlay bottom

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -496,6 +496,7 @@
     align-items: flex-end;
     border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
+    overflow-wrap: anywhere;
 }
 
 .mo-card-content-top {


### PR DESCRIPTION
CSS was extending long texts, making it hard to read the model name.

## Before:
![Screenshot from 2023-08-21 16-14-30](https://github.com/alexandersokol/sd-model-organizer/assets/7660643/f0c52079-da81-47bb-9316-8fe96b836f12)


## After fix:
![Screenshot from 2023-08-21 16-14-24](https://github.com/alexandersokol/sd-model-organizer/assets/7660643/fbec26e2-f923-47e1-aea9-ac5a4a97dad1)
