### PR TITLE
Fixed binding going missing when editing an existing record

### DIFF
--- a/scripts/mo/ui_edit.py
+++ b/scripts/mo/ui_edit.py
@@ -249,6 +249,7 @@ def _get_bind_location_dropdown_update(model_type_value, current_location: str):
     chosen = 'None'
     if current_location:
         model_local_path = current_location.replace(env.get_model_path(model_type) + '/', '')
+        model_local_path = model_local_path.replace(lookup_dir, '') 
         if model_local_path in choices:
             chosen = model_local_path
 


### PR DESCRIPTION
When editing an existing record the localy bound file does not get found, that's because when checking if a model is present it compares the filepath + model to a list of model names without the filepath.
This pullrequest fixes this by removing the filepath from the model.