### PR TITLE
Civitai duplicate check for existing records.

### DIFF
--- a/scripts/mo/data/sqlite_storage.py
+++ b/scripts/mo/data/sqlite_storage.py
@@ -229,6 +229,15 @@ class SQLiteStorage(Storage):
         for row in rows:
             result.append(map_row_to_record(row))
         return result
+    
+    def get_records_by_query(self, query: str) -> List:
+        cursor = self._connection().cursor()
+        cursor.execute(query)
+        rows = cursor.fetchall()
+        result = []
+        for row in rows:
+            result.append(map_row_to_record(row))
+        return result
 
     def add_record(self, record: Record):
         cursor = self._connection().cursor()

--- a/scripts/mo/environment.py
+++ b/scripts/mo/environment.py
@@ -77,6 +77,7 @@ class Environment:
     card_height: Callable[[], str]
     is_debug_mode_enabled: Callable[[], bool]
     api_key: Callable[[], str]
+    check_duplicates: Callable[[], bool]
 
     def is_storage_initialized(self) -> bool:
         return hasattr(self, 'storage')

--- a/scripts/mo/ui_styled_html.py
+++ b/scripts/mo/ui_styled_html.py
@@ -15,34 +15,34 @@ _NO_PREVIEW_LIGHT = 'file=extensions/sd-model-organizer/pic/no-preview-light.png
 
 def alert_danger(value) -> str:
     if isinstance(value, list):
-        text = "<br>".join(value)
+        text = "<br>".join([html.escape(s) for s in value])
     else:
-        text = value
-    return f'<div class="mo-alert mo-alert-danger">{html.escape(text)}</div>'
+        text = html.escape(value)
+    return f'<div class="mo-alert mo-alert-danger">{text}</div>'
 
 
 def alert_primary(value) -> str:
     if isinstance(value, list):
-        text = "<br>".join(value)
+        text = "<br>".join([html.escape(s) for s in value])
     else:
-        text = value
-    return f'<div class="mo-alert mo-alert-primary">{html.escape(text)}</div>'
+        text = html.escape(value)
+    return f'<div class="mo-alert mo-alert-primary">{text}</div>'
 
 
 def alert_success(value) -> str:
     if isinstance(value, list):
-        text = "<br>".join(value)
+        text = "<br>".join([html.escape(s) for s in value])
     else:
-        text = value
-    return f'<div class="mo-alert mo-alert-success">{html.escape(text)}</div>'
+        text = html.escape(value)
+    return f'<div class="mo-alert mo-alert-success">{text}</div>'
 
 
 def alert_warning(value) -> str:
     if isinstance(value, list):
-        text = "<br>".join(value)
+        text = "<br>".join([html.escape(s) for s in value])
     else:
-        text = value
-    return f'<div class="mo-alert mo-alert-warning">{html.escape(text)}</div>'
+        text = html.escape(value)
+    return f'<div class="mo-alert mo-alert-warning">{text}</div>'
 
 
 def _limit_description(text):

--- a/scripts/model_organizer.py
+++ b/scripts/model_organizer.py
@@ -134,6 +134,12 @@ env.api_key = (
     else ""
 )
 
+env.check_duplicates = (
+    lambda: shared.opts.mo_check_duplicates
+    if hasattr(shared.opts, 'mo_check_duplicates')
+    else ""
+)
+
 env.model_path = (
     lambda: shared.opts.mo_model_path
     if hasattr(shared.opts, 'mo_model_path') and shared.opts.mo_model_path
@@ -198,6 +204,7 @@ def on_ui_settings():
         'mo_prefill_neg_prompt': OptionInfo(True, 'When creating a record based on local file, automatically import the added negative prompts'),
         'mo_autobind_file': OptionInfo(True, 'Automatically bind record to local file'),
         'mo_api_key': OptionInfo("", "Civitai API Key. Create an API key under 'https://civitai.com/user/account' all the way at the bottom. Don't share the token!"),
+        'mo_check_duplicates': OptionInfo(False, "Should a duplicate check be performed, upon fetching a file from Civitai"),
     }
 
     dir_opts = {


### PR DESCRIPTION
This is my basic implementation of #88 

This feature is disabled by default but can be toggled on within the settings.
When fetching a model from civitai through the importer, a query is executed that fetches all records that share the same URL with the fetched model. When one/multiple are detected a warning label will be shown to the user to inform them which versions have been added as a record already.
![grafik](https://github.com/alexandersokol/sd-model-organizer/assets/6223515/eb1dcefe-bb5e-4641-9450-7d3d8ba0b008)


While implementing this feature I also noticed that the warning/alert labels etc. were broken when passing in a list. The `<br>` that were supposed to list the strings from the list passed into these methods but the `html.escape()` call was made afterwards causing all html tags to be escaped, rendering them useless.
To fix this I simply escape only the entries of the list and then join them together.