### PR TITLE
remove updated_at field from civit.ai response parsing

### DIFF
--- a/scripts/mo/data/mapping_utils.py
+++ b/scripts/mo/data/mapping_utils.py
@@ -5,7 +5,7 @@ def create_version_dict(version_data):
     version = {
         'id': version_data['id'],
         'name': version_data['name'],
-        'updated_at': version_data['updatedAt'],
+        # 'updated_at': version_data['updatedAt'],
     }
 
     trained_words = []

--- a/scripts/mo/ui_import_export.py
+++ b/scripts/mo/ui_import_export.py
@@ -66,6 +66,9 @@ def import_export_ui_block():
             gr.Markdown('## Records import/export')
             gr.Markdown('')
             back_button = gr.Button('Back')
+        with gr.Tab("Import Civitai URL"):
+            with gr.Column():
+                civitai_import_ui_block()
         with gr.Tab("Import JSON"):
             import_file_widget = gr.File(label='Import .json file', file_types=['.json'])
             import_result_widget = gr.HTML()
@@ -82,9 +85,6 @@ def import_export_ui_block():
                                            value='Export All')
             export_button = gr.Button(value='Export')
             export_file_widget = gr.File(visible=False)
-        with gr.Tab("Import Civitai URL"):
-            with gr.Column():
-                civitai_import_ui_block()
 
     back_button.click(fn=None, _js='navigateBack')
 


### PR DESCRIPTION
1. remove updated_at field from civit.ai response parsing [issue](https://github.com/alexandersokol/sd-model-organizer/issues/91)
2. rearrange import/export tabs